### PR TITLE
Added Ombi installer to fix dependancy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vscode/
 .ignore/
+workspace.code-workspace

--- a/ombi.sh
+++ b/ombi.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+readonly DETECTED_PUID=${SUDO_UID:-$UID}
+readonly DETECTED_UNAME=$(id -un "${DETECTED_PUID}" 2> /dev/null || true)
+readonly DETECTED_PGID=$(id -g "${DETECTED_PUID}" 2> /dev/null || true)
+readonly DETECTED_UGROUP=$(id -gn "${DETECTED_PUID}" 2> /dev/null || true)
+readonly DETECTED_HOMEDIR=$(eval echo "~${DETECTED_UNAME}" 2> /dev/null || true)
+readonly FIRSTRUN_DIR="${DETECTED_HOMEDIR}/OpenFLIXR2.FirstRun"
+readonly FIRSTRUN_DATA_DIR="${DETECTED_HOMEDIR}/.FirstRun"
+readonly FIRSTRUN_LOG_DIR="${FIRSTRUN_DATA_DIR}/logs"
+readonly ombidir="/opt/ombi"
+
+if [[ ! -d "${ombidir}" ]]; then
+    mkdir ${ombidir}
+fi
+
+# From https://github.com/linuxserver/docker-ombi/blob/master/Dockerfile#L22
+OMBI_RELEASE=$(curl -sX GET "https://api.github.com/repos/tidusjar/Ombi/releases/latest" | awk '/tag_name/{print $4;exit}' FS='[""]');
+
+curl -o /tmp/ombi-src.tar.gz -L "https://github.com/tidusjar/Ombi/releases/download/${OMBI_RELEASE}/linux.tar.gz"
+
+if [[ -f /tmp/ombi-src.tar.gz ]]; then
+    tar xzf /tmp/ombi-src.tar.gz -C "${ombidir}"
+else
+    info "Failed to retrieve or extra Ombi"
+fi
+
+chmod +x "${ombidir}/Ombi"
+
+cd ${ombidir}
+
+apt install -y libicu-dev libunwind8 libcurl4-openssl-dev
+exec bash "${ombidir}/Ombi" &
+sleep 60
+pkill Ombi
+cd ${FIRSTRUN_DIR}

--- a/run_me.sh
+++ b/run_me.sh
@@ -131,6 +131,9 @@ if [[ ${TERM:0:6} != "screen" ]]; then
     info "Fixing setupopenflixr symlink"
     echo "openflixr" | sudo -S bash /opt/OpenFLIXR2.SetupScript/main.sh -s
 
+    info "Correcting unmet dependency"
+    bash ${FIRSTRUN_DIR}/ombi.sh
+
     info "Running startup script"
     bash ${FIRSTRUN_DIR}/startup.sh
 fi


### PR DESCRIPTION
Ombi is not installed in the base image, as such the setup fails.

This script installs Ombi to meet the requirement allowing the setup to continue.